### PR TITLE
Remove warning about deprecated method of installing test package.

### DIFF
--- a/tests/resources/sut/install-dist-package.sh
+++ b/tests/resources/sut/install-dist-package.sh
@@ -2,4 +2,4 @@
 set -ex
 cd /tmp
 export VERSION=$( ls /mnt/dist/testinfra-bdd-*.gz | cut -d- -f3 | cut -d. -f1,2,3 )
-pip install -q /mnt/dist/testinfra-bdd-*.tar.gz
+pip install --force-reinstall --quiet /mnt/dist/testinfra-bdd-*.tar.gz


### PR DESCRIPTION
Was receiving a deprecation warning about reinstalling a source package.  Added the `--force-install` flag.